### PR TITLE
issue 287: change wording around NOC rules

### DIFF
--- a/src/a/index.html
+++ b/src/a/index.html
@@ -30,17 +30,18 @@
         <label for="year">Year:</label>
         <select name="year" id="year" class="select-css" onchange="setState(['year'], [this.value]); lookupMakeModelYear();">
         </select>
-        <h3>
-          Don't see your car listed? Choose "NOC (Not Otherwise Classified)" as your Make
-          and find your class using the "Catch-All" categories.
+        <h3 id="nocNotice">
+          If your car not listed then you should attempt to class your car using the NOC (Not Otherwise Classified)
+          rules. This method is complicated and not fully supported on this website.
+          </br>
+          Please refer to the <a href="https://www.scca.com/pages/solo-cars-and-rules">SCCA rulebook</a>
+          if this happens, or get in contact with an experienced autocrosser to help you out!
         </h3>
-        </br>
-        </br>
+        <h3>
+          Choose your class below. Classes are <i>roughly</i> in order from least to most
+          modified, from left to right.
+        </h3>
       </div>
-      <h3>
-        Choose your class below. Classes are <i>roughly</i> in order from least to most
-        modified, from left to right.
-      </h3>
       <div class="classesTable">
         <table id="classesTable">
           <tr>
@@ -177,6 +178,10 @@
           </tr>
         </table>
       </div>
+      <h3>
+        Have feedback? This website is open source. Any feedback/contributions are welcome
+        <a href="https://github.com/Bjorn248/scca_classifier" target="_blank" rel="noopener noreferrer">on Github</a>.
+      </h3>
     </div>
   </body>
 </html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -288,7 +288,7 @@
 }
 
 .center {
-  padding: 70px 0;
+  padding: 15px 0;
   text-align: center;
 }
 


### PR DESCRIPTION
# Context
We want to change the wording around the not otherwise classified case since it isn't well supported on the website. See #287 

# Changes
* add github notice to bottom of autox index
* change padding of `center` css class to 15 px (not sure why it was so big to begin with)
* add new wording on autox index around NOC classes, instructing folks to reference the rules if their car is not listed