### PR TITLE
Fix stock 4C classification

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -290,12 +290,12 @@ const allSoloCars = {
       'all': ['hs', 'fsp', 'sm', 'dp', 'xp', 'xb'],
     },
     '4C (incl. Spider)': {
-      '2015': ['ss', 'ssr', 'sst', 'ssm', 'xp', 'xu'],
-      '2016': ['ss', 'ssr', 'sst', 'ssm', 'xp', 'xu'],
-      '2017': ['ss', 'ssr', 'sst', 'ssm', 'xp', 'xu'],
-      '2018': ['ss', 'ssr', 'sst', 'ssm', 'xp', 'xu'],
-      '2019': ['ss', 'ssr', 'sst', 'ssm', 'xp', 'xu'],
-      '2020': ['ss', 'ssr', 'sst', 'ssm', 'xp', 'xu'],
+      '2015': ['as', 'ssr', 'sst', 'ssm', 'xp', 'xu'],
+      '2016': ['as', 'ssr', 'sst', 'ssm', 'xp', 'xu'],
+      '2017': ['as', 'ssr', 'sst', 'ssm', 'xp', 'xu'],
+      '2018': ['as', 'ssr', 'sst', 'ssm', 'xp', 'xu'],
+      '2019': ['as', 'ssr', 'sst', 'ssm', 'xp', 'xu'],
+      '2020': ['as', 'ssr', 'sst', 'ssm', 'xp', 'xu'],
     },
     '164 (non-S)': {
       '1991': ['hs', 'sm', 'xp', 'xa'],


### PR DESCRIPTION
The website lists the 4C as SS but the rule book lists it as AS. This can be found on page 184 of the 2024 rulebook found here:

https://www.scca.com/downloads/71400-2024-rulebook-april/download