### PR TITLE
issue 302 fix cayman gts 4.0 classing

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -6705,8 +6705,11 @@ const allSoloCars = {
       '2021': ['ss', 'xp', 'xu', 'ssm'],
       '2022': ['ss', 'xp', 'xu', 'ssm'],
       '2023': ['ss', 'xp', 'xu', 'ssm'],
+      '2024': ['ss', 'xp', 'xu', 'ssm'],
     },
     'Cayman GT4 RS': {
+      '2020': ['ss', 'xp', 'xu', 'ssm'],
+      '2021': ['ss', 'xp', 'xu', 'ssm'],
       '2022': ['ss', 'xp', 'xu', 'ssm'],
       '2023': ['ss', 'xp', 'xu', 'ssm'],
       '2024': ['ss', 'xp', 'xu', 'ssm'],
@@ -6750,6 +6753,13 @@ const allSoloCars = {
       '2019': ['as', 'xp', 'xu', 'ssm'],
       '2020': ['as', 'xp', 'xu', 'ssm'],
       '2021': ['as', 'xp', 'xu', 'ssm'],
+    },
+    'Cayman Spyder/Spyder RS': {
+      '2020': ['ss', 'xp', 'xu', 'ssm'],
+      '2021': ['ss', 'xp', 'xu', 'ssm'],
+      '2022': ['ss', 'xp', 'xu', 'ssm'],
+      '2023': ['ss', 'xp', 'xu', 'ssm'],
+      '2024': ['ss', 'xp', 'xu', 'ssm'],
     },
     'Macan (all)': {
       '2015': ['bs', 'xp', 'xa', 'sm'],

--- a/src/common.js
+++ b/src/common.js
@@ -6711,7 +6711,7 @@ const allSoloCars = {
       '2023': ['ss', 'xp', 'xu', 'ssm'],
       '2024': ['ss', 'xp', 'xu', 'ssm'],
     },
-    'Cayman GTS & GTS 4.0 & Spyder': {
+    'Cayman GTS': {
       '2015': ['as', 'sst', 'ssp', 'xp', 'xa', 'ssm'],
       '2016': ['as', 'sst', 'ssp', 'xp', 'xa', 'ssm'],
       '2017': ['as', 'ssp', 'xp', 'xu', 'ssm'],
@@ -6722,6 +6722,13 @@ const allSoloCars = {
       '2022': ['as', 'ssp', 'xp', 'xu', 'ssm'],
       '2023': ['as', 'ssp', 'xp', 'xu', 'ssm'],
       '2024': ['as', 'ssp', 'xp', 'xu', 'ssm'],
+    },
+    'Cayman GTS 4.0': {
+      '2020': ['ss', 'ssp', 'xp', 'xu', 'ssm'],
+      '2021': ['ss', 'ssp', 'xp', 'xu', 'ssm'],
+      '2022': ['ss', 'ssp', 'xp', 'xu', 'ssm'],
+      '2023': ['ss', 'ssp', 'xp', 'xu', 'ssm'],
+      '2024': ['ss', 'ssp', 'xp', 'xu', 'ssm'],
     },
     'Cayman R': {
       '2012': ['as', 'ssp', 'fp', 'xp', 'xu', 'sm'],

--- a/templates/common.js.tmpl
+++ b/templates/common.js.tmpl
@@ -6648,8 +6648,11 @@ const allSoloCars = {
       '2021': ['ss', 'xp', 'xu', 'ssm'],
       '2022': ['ss', 'xp', 'xu', 'ssm'],
       '2023': ['ss', 'xp', 'xu', 'ssm'],
+      '2024': ['ss', 'xp', 'xu', 'ssm'],
     },
     'Cayman GT4 RS': {
+      '2020': ['ss', 'xp', 'xu', 'ssm'],
+      '2021': ['ss', 'xp', 'xu', 'ssm'],
       '2022': ['ss', 'xp', 'xu', 'ssm'],
       '2023': ['ss', 'xp', 'xu', 'ssm'],
       '2024': ['ss', 'xp', 'xu', 'ssm'],
@@ -6693,6 +6696,13 @@ const allSoloCars = {
       '2019': ['as', 'xp', 'xu', 'ssm'],
       '2020': ['as', 'xp', 'xu', 'ssm'],
       '2021': ['as', 'xp', 'xu', 'ssm'],
+    },
+    'Cayman Spyder/Spyder RS': {
+      '2020': ['ss', 'xp', 'xu', 'ssm'],
+      '2021': ['ss', 'xp', 'xu', 'ssm'],
+      '2022': ['ss', 'xp', 'xu', 'ssm'],
+      '2023': ['ss', 'xp', 'xu', 'ssm'],
+      '2024': ['ss', 'xp', 'xu', 'ssm'],
     },
     'Macan (all)': {
       '2015': ['bs', 'xp', 'xa', 'sm'],

--- a/templates/common.js.tmpl
+++ b/templates/common.js.tmpl
@@ -6654,7 +6654,7 @@ const allSoloCars = {
       '2023': ['ss', 'xp', 'xu', 'ssm'],
       '2024': ['ss', 'xp', 'xu', 'ssm'],
     },
-    'Cayman GTS & GTS 4.0 & Spyder': {
+    'Cayman GTS': {
       '2015': ['as', 'sst', 'ssp', 'xp', 'xa', 'ssm'],
       '2016': ['as', 'sst', 'ssp', 'xp', 'xa', 'ssm'],
       '2017': ['as', 'ssp', 'xp', 'xu', 'ssm'],
@@ -6665,6 +6665,13 @@ const allSoloCars = {
       '2022': ['as', 'ssp', 'xp', 'xu', 'ssm'],
       '2023': ['as', 'ssp', 'xp', 'xu', 'ssm'],
       '2024': ['as', 'ssp', 'xp', 'xu', 'ssm'],
+    },
+    'Cayman GTS 4.0': {
+      '2020': ['ss', 'ssp', 'xp', 'xu', 'ssm'],
+      '2021': ['ss', 'ssp', 'xp', 'xu', 'ssm'],
+      '2022': ['ss', 'ssp', 'xp', 'xu', 'ssm'],
+      '2023': ['ss', 'ssp', 'xp', 'xu', 'ssm'],
+      '2024': ['ss', 'ssp', 'xp', 'xu', 'ssm'],
     },
     'Cayman R': {
       '2012': ['as', 'ssp', 'fp', 'xp', 'xu', 'sm'],


### PR DESCRIPTION
addresses #302 to fix the classing of the Cayman GTS 4.0

Changes:
* moves Cayman GTS 4.0 into its own model dropdown
* changes Cayman GTS 4.0 to be in SS
* ~removes Cayman Spyder from model listing (hopefully this is OK?) If not, which class should it be in?~
* moves Cayman Spyder/Spyder RS into its own model