### PR TITLE
Updated 2001/2002 M roadster classification

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1397,8 +1397,8 @@ const allSoloCars = {
       '1998': ['cs', 'cst', 'csp', 'sm', 'xp', 'xa'],
       '1999': ['cs', 'cst', 'csp', 'sm', 'xp', 'xa'],
       '2000': ['cs', 'cst', 'csp', 'sm', 'xp', 'xa'],
-      '2001': ['bs', 'cst', 'csp', 'sm', 'xp', 'xa'],
-      '2002': ['bs', 'cst', 'csp', 'sm', 'xp', 'xa'],
+      '2001': ['cs', 'cst', 'csp', 'sm', 'xp', 'xa'],
+      '2002': ['cs', 'cst', 'csp', 'sm', 'xp', 'xa'],
     },
     'X1': {
       '2013': ['bst', 'sm', 'xp', 'xa'],

--- a/templates/common.js.tmpl
+++ b/templates/common.js.tmpl
@@ -1340,8 +1340,8 @@ const allSoloCars = {
       '1998': ['cs', 'cst', 'csp', 'sm', 'xp', 'xa'],
       '1999': ['cs', 'cst', 'csp', 'sm', 'xp', 'xa'],
       '2000': ['cs', 'cst', 'csp', 'sm', 'xp', 'xa'],
-      '2001': ['bs', 'cst', 'csp', 'sm', 'xp', 'xa'],
-      '2002': ['bs', 'cst', 'csp', 'sm', 'xp', 'xa'],
+      '2001': ['cs', 'cst', 'csp', 'sm', 'xp', 'xa'],
+      '2002': ['cs', 'cst', 'csp', 'sm', 'xp', 'xa'],
     },
     'X1': {
       '2013': ['bst', 'sm', 'xp', 'xa'],


### PR DESCRIPTION
Fixed S54 M Roadster being listed as B Street and not C Street. (Honestly looks like a typo on the rules missing the M)