### PR TITLE
Add GST class to Kia Forte GT (2020-2024)

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -4486,11 +4486,11 @@ const allSoloCars = {
       'all': ['hs', 'est', 'fsp', 'xp', 'xa', 'sm'],
     },
     'Forte GT': {
-      '2020': ['hs', 'xp', 'xa', 'sm'],
-      '2021': ['hs', 'xp', 'xa', 'sm'],
-      '2022': ['hs', 'xp', 'xa', 'sm'],
-      '2023': ['hs', 'xp', 'xa', 'sm'],
-      '2024': ['hs', 'xp', 'xa', 'sm'],
+      '2020': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2021': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2022': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2023': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2024': ['hs', 'gst', 'xp', 'xa', 'sm'],
     },
     'Forte Koup (non-turbo)': {
       'all': ['hs', 'est', 'dsp', 'xp', 'xa', 'sm'],

--- a/templates/common.js.tmpl
+++ b/templates/common.js.tmpl
@@ -4356,11 +4356,11 @@ const allSoloCars = {
       'all': ['hs', 'est', 'fsp', 'xp', 'xa', 'sm'],
     },
     'Forte GT': {
-      '2020': ['hs', 'xp', 'xa', 'sm'],
-      '2021': ['hs', 'xp', 'xa', 'sm'],
-      '2022': ['hs', 'xp', 'xa', 'sm'],
-      '2023': ['hs', 'xp', 'xa', 'sm'],
-      '2024': ['hs', 'xp', 'xa', 'sm'],
+      '2020': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2021': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2022': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2023': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2024': ['hs', 'gst', 'xp', 'xa', 'sm'],
     },
     'Forte Koup (non-turbo)': {
       'all': ['hs', 'est', 'dsp', 'xp', 'xa', 'sm'],


### PR DESCRIPTION
## Summary
- Add GST class to Kia Forte GT for model years 2020-2024
- Forte GT is a turbocharged variant (1.6L turbo) and should have GST classification consistent with Forte Koup Turbo and Forte Turbo

Fixes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)