### PR TITLE
Issue 359: April 2025 Fastrack discrete additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ rr_rules.*
 rules_layout.*
 rules_raw.*
 old_rules.*
+
+# goenv
+.go-version

--- a/src/common.js
+++ b/src/common.js
@@ -1544,6 +1544,7 @@ const allSoloCars = {
       '2021': ['bs', 'bst', 'sm', 'xp', 'xa'],
       '2022': ['bs', 'bst', 'sm', 'xp', 'xa'],
       '2023': ['bs', 'bst', 'sm', 'xp', 'xa'],
+      '2024': ['ss', 'sm', 'xp', 'xu'],
       '2025': ['ss', 'sm', 'xp', 'xu'],
     },
     'M5 CS': {

--- a/src/common.js
+++ b/src/common.js
@@ -1545,6 +1545,9 @@ const allSoloCars = {
       '2022': ['bs', 'bst', 'sm', 'xp', 'xa'],
       '2023': ['bs', 'bst', 'sm', 'xp', 'xa'],
     },
+    'M5 (G90)': {
+      '2025': ['ss', 'sm', 'xp', 'xu'],
+    },
     'M5 CS': {
       '2022': ['ss', 'sst', 'sm', 'xp', 'xu'],
     },
@@ -4309,13 +4312,17 @@ const allSoloCars = {
       '2023': ['bs', 'ssr', 'xp', 'xa', 'sm'],
     },
     'F-Type R & SVR': {
-      '2018': ['as', 'xp', 'xu', 'sm'],
-      '2019': ['as', 'xp', 'xu', 'sm'],
-      '2020': ['as', 'xp', 'xu', 'sm'],
-      '2021': ['as', 'xp', 'xu', 'sm'],
-      '2022': ['as', 'xp', 'xu', 'sm'],
-      '2023': ['as', 'xp', 'xu', 'sm'],
-      '2024': ['as', 'xp', 'xu', 'sm'],
+      '2014': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2015': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2016': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2017': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2018': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2019': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2020': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2021': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2022': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2023': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2024': ['as', 'esp', 'xp', 'xu', 'sm'],
     },
     'I-Pace': {
       '2019': ['evx'],
@@ -7149,6 +7156,10 @@ const allSoloCars = {
       '2013': ['as', 'ssr', 'xp', 'xu', 'ssm'],
       '2016': ['ss', 'ssr', 'xp', 'xu', 'ssm'],
     },
+    'Boxster Spyder RS (718)': {
+      '2024': ['ss', 'xp', 'xu', 'ssm'],
+      '2025': ['ss', 'xp', 'xu', 'ssm'],
+    },
     'Carrera 2 & Carrera 4 (964)': {
       '1989': ['cs', 'xp', 'xa', 'ssm'],
       '1990': ['cs', 'xp', 'xa', 'ssm'],
@@ -7777,6 +7788,17 @@ const allSoloCars = {
     },
     'Impreza': {
       'all': ['dsp', 'xp', 'xa', 'sm'],
+    },
+    'Impreza (2017-2025)': {
+      '2017': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2018': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2019': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2020': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2021': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2022': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2023': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2024': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2025': ['hs', 'gst', 'xp', 'xa', 'sm'],
     },
     'Impreza 2.0i': {
       '2012': ['hs', 'est', 'fsp', 'xp', 'xa', 'sm'],
@@ -8673,9 +8695,10 @@ const allSoloCars = {
       '2019': ['hs', 'gst', 'dsp', 'ep', 'xp', 'xa', 'sm', 'smf'],
       '2020': ['hs', 'gst', 'dsp', 'ep', 'xp', 'xa', 'sm', 'smf'],
       '2021': ['hs', 'gst', 'dsp', 'ep', 'xp', 'xa', 'sm', 'smf'],
-      '2022': ['gs', 'gst', 'dsp', 'ep', 'xp', 'xa', 'sm', 'smf'],
-      '2023': ['gs', 'gst', 'dsp', 'ep', 'xp', 'xa', 'sm', 'smf'],
-      '2024': ['gs', 'gst', 'dsp', 'ep', 'xp', 'xa', 'sm', 'smf'],
+      '2022': ['gs', 'gst', 'dsp', 'ep', 'fsp', 'xp', 'xa', 'sm', 'smf'],
+      '2023': ['gs', 'gst', 'dsp', 'ep', 'fsp', 'xp', 'xa', 'sm', 'smf'],
+      '2024': ['gs', 'gst', 'dsp', 'ep', 'fsp', 'xp', 'xa', 'sm', 'smf'],
+      '2025': ['gs', 'gst', 'dsp', 'ep', 'fsp', 'xp', 'xa', 'sm', 'smf'],
     },
     'Golf R': {
       '2012': ['ds', 'dsp', 'sm', 'ep', 'xp', 'xa', 'sm'],

--- a/src/common.js
+++ b/src/common.js
@@ -7153,8 +7153,6 @@ const allSoloCars = {
       '2012': ['as', 'sst', 'ssr', 'xp', 'xu', 'ssm'],
       '2013': ['as', 'ssr', 'xp', 'xu', 'ssm'],
       '2016': ['ss', 'ssr', 'xp', 'xu', 'ssm'],
-    },
-    'Boxster Spyder RS (718)': {
       '2024': ['ss', 'xp', 'xu', 'ssm'],
       '2025': ['ss', 'xp', 'xu', 'ssm'],
     },
@@ -7787,7 +7785,12 @@ const allSoloCars = {
     'Impreza': {
       'all': ['dsp', 'xp', 'xa', 'sm'],
     },
-    'Impreza (2017-2025)': {
+    'Impreza 2.0i': {
+      '2012': ['hs', 'est', 'fsp', 'xp', 'xa', 'sm'],
+      '2013': ['hs', 'est', 'fsp', 'xp', 'xa', 'sm'],
+      '2014': ['hs', 'est', 'xp', 'xa', 'sm'],
+      '2015': ['hs', 'est', 'xp', 'xa', 'sm'],
+      '2016': ['hs', 'est', 'xp', 'xa', 'sm'],
       '2017': ['hs', 'gst', 'xp', 'xa', 'sm'],
       '2018': ['hs', 'gst', 'xp', 'xa', 'sm'],
       '2019': ['hs', 'gst', 'xp', 'xa', 'sm'],
@@ -7797,13 +7800,6 @@ const allSoloCars = {
       '2023': ['hs', 'gst', 'xp', 'xa', 'sm'],
       '2024': ['hs', 'gst', 'xp', 'xa', 'sm'],
       '2025': ['hs', 'gst', 'xp', 'xa', 'sm'],
-    },
-    'Impreza 2.0i': {
-      '2012': ['hs', 'est', 'fsp', 'xp', 'xa', 'sm'],
-      '2013': ['hs', 'est', 'fsp', 'xp', 'xa', 'sm'],
-      '2014': ['hs', 'est', 'xp', 'xa', 'sm'],
-      '2015': ['hs', 'est', 'xp', 'xa', 'sm'],
-      '2016': ['hs', 'est', 'xp', 'xa', 'sm'],
     },
     'Impreza 2.5 (non-turbo)': {
       'all': ['hs', 'xp', 'xa', 'sm'],

--- a/src/common.js
+++ b/src/common.js
@@ -1544,8 +1544,6 @@ const allSoloCars = {
       '2021': ['bs', 'bst', 'sm', 'xp', 'xa'],
       '2022': ['bs', 'bst', 'sm', 'xp', 'xa'],
       '2023': ['bs', 'bst', 'sm', 'xp', 'xa'],
-    },
-    'M5 (G90)': {
       '2025': ['ss', 'sm', 'xp', 'xu'],
     },
     'M5 CS': {

--- a/templates/common.js.tmpl
+++ b/templates/common.js.tmpl
@@ -1412,6 +1412,7 @@ const allSoloCars = {
       '2021': ['bs', 'bst', 'sm', 'xp', 'xa'],
       '2022': ['bs', 'bst', 'sm', 'xp', 'xa'],
       '2023': ['bs', 'bst', 'sm', 'xp', 'xa'],
+      '2024': ['ss', 'sm', 'xp', 'xu'],
       '2025': ['ss', 'sm', 'xp', 'xu'],
     },
     'M5 CS': {

--- a/templates/common.js.tmpl
+++ b/templates/common.js.tmpl
@@ -1412,8 +1412,6 @@ const allSoloCars = {
       '2021': ['bs', 'bst', 'sm', 'xp', 'xa'],
       '2022': ['bs', 'bst', 'sm', 'xp', 'xa'],
       '2023': ['bs', 'bst', 'sm', 'xp', 'xa'],
-    },
-    'M5 (G90)': {
       '2025': ['ss', 'sm', 'xp', 'xu'],
     },
     'M5 CS': {

--- a/templates/common.js.tmpl
+++ b/templates/common.js.tmpl
@@ -7021,8 +7021,6 @@ const allSoloCars = {
       '2012': ['as', 'sst', 'ssr', 'xp', 'xu', 'ssm'],
       '2013': ['as', 'ssr', 'xp', 'xu', 'ssm'],
       '2016': ['ss', 'ssr', 'xp', 'xu', 'ssm'],
-    },
-    'Boxster Spyder RS (718)': {
       '2024': ['ss', 'xp', 'xu', 'ssm'],
       '2025': ['ss', 'xp', 'xu', 'ssm'],
     },
@@ -7655,7 +7653,12 @@ const allSoloCars = {
     'Impreza': {
       'all': ['dsp', 'xp', 'xa', 'sm'],
     },
-    'Impreza (2017-2025)': {
+    'Impreza 2.0i': {
+      '2012': ['hs', 'est', 'fsp', 'xp', 'xa', 'sm'],
+      '2013': ['hs', 'est', 'fsp', 'xp', 'xa', 'sm'],
+      '2014': ['hs', 'est', 'xp', 'xa', 'sm'],
+      '2015': ['hs', 'est', 'xp', 'xa', 'sm'],
+      '2016': ['hs', 'est', 'xp', 'xa', 'sm'],
       '2017': ['hs', 'gst', 'xp', 'xa', 'sm'],
       '2018': ['hs', 'gst', 'xp', 'xa', 'sm'],
       '2019': ['hs', 'gst', 'xp', 'xa', 'sm'],
@@ -7665,13 +7668,6 @@ const allSoloCars = {
       '2023': ['hs', 'gst', 'xp', 'xa', 'sm'],
       '2024': ['hs', 'gst', 'xp', 'xa', 'sm'],
       '2025': ['hs', 'gst', 'xp', 'xa', 'sm'],
-    },
-    'Impreza 2.0i': {
-      '2012': ['hs', 'est', 'fsp', 'xp', 'xa', 'sm'],
-      '2013': ['hs', 'est', 'fsp', 'xp', 'xa', 'sm'],
-      '2014': ['hs', 'est', 'xp', 'xa', 'sm'],
-      '2015': ['hs', 'est', 'xp', 'xa', 'sm'],
-      '2016': ['hs', 'est', 'xp', 'xa', 'sm'],
     },
     'Impreza 2.5 (non-turbo)': {
       'all': ['hs', 'xp', 'xa', 'sm'],

--- a/templates/common.js.tmpl
+++ b/templates/common.js.tmpl
@@ -1413,6 +1413,9 @@ const allSoloCars = {
       '2022': ['bs', 'bst', 'sm', 'xp', 'xa'],
       '2023': ['bs', 'bst', 'sm', 'xp', 'xa'],
     },
+    'M5 (G90)': {
+      '2025': ['ss', 'sm', 'xp', 'xu'],
+    },
     'M5 CS': {
       '2022': ['ss', 'sst', 'sm', 'xp', 'xu'],
     },
@@ -4177,13 +4180,17 @@ const allSoloCars = {
       '2023': ['bs', 'ssr', 'xp', 'xa', 'sm'],
     },
     'F-Type R & SVR': {
-      '2018': ['as', 'xp', 'xu', 'sm'],
-      '2019': ['as', 'xp', 'xu', 'sm'],
-      '2020': ['as', 'xp', 'xu', 'sm'],
-      '2021': ['as', 'xp', 'xu', 'sm'],
-      '2022': ['as', 'xp', 'xu', 'sm'],
-      '2023': ['as', 'xp', 'xu', 'sm'],
-      '2024': ['as', 'xp', 'xu', 'sm'],
+      '2014': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2015': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2016': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2017': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2018': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2019': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2020': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2021': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2022': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2023': ['as', 'esp', 'xp', 'xu', 'sm'],
+      '2024': ['as', 'esp', 'xp', 'xu', 'sm'],
     },
     'I-Pace': {
       '2019': ['evx'],
@@ -7017,6 +7024,10 @@ const allSoloCars = {
       '2013': ['as', 'ssr', 'xp', 'xu', 'ssm'],
       '2016': ['ss', 'ssr', 'xp', 'xu', 'ssm'],
     },
+    'Boxster Spyder RS (718)': {
+      '2024': ['ss', 'xp', 'xu', 'ssm'],
+      '2025': ['ss', 'xp', 'xu', 'ssm'],
+    },
     'Carrera 2 & Carrera 4 (964)': {
       '1989': ['cs', 'xp', 'xa', 'ssm'],
       '1990': ['cs', 'xp', 'xa', 'ssm'],
@@ -7645,6 +7656,17 @@ const allSoloCars = {
     },
     'Impreza': {
       'all': ['dsp', 'xp', 'xa', 'sm'],
+    },
+    'Impreza (2017-2025)': {
+      '2017': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2018': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2019': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2020': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2021': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2022': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2023': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2024': ['hs', 'gst', 'xp', 'xa', 'sm'],
+      '2025': ['hs', 'gst', 'xp', 'xa', 'sm'],
     },
     'Impreza 2.0i': {
       '2012': ['hs', 'est', 'fsp', 'xp', 'xa', 'sm'],
@@ -8541,9 +8563,10 @@ const allSoloCars = {
       '2019': ['hs', 'gst', 'dsp', 'ep', 'xp', 'xa', 'sm', 'smf'],
       '2020': ['hs', 'gst', 'dsp', 'ep', 'xp', 'xa', 'sm', 'smf'],
       '2021': ['hs', 'gst', 'dsp', 'ep', 'xp', 'xa', 'sm', 'smf'],
-      '2022': ['gs', 'gst', 'dsp', 'ep', 'xp', 'xa', 'sm', 'smf'],
-      '2023': ['gs', 'gst', 'dsp', 'ep', 'xp', 'xa', 'sm', 'smf'],
-      '2024': ['gs', 'gst', 'dsp', 'ep', 'xp', 'xa', 'sm', 'smf'],
+      '2022': ['gs', 'gst', 'dsp', 'ep', 'fsp', 'xp', 'xa', 'sm', 'smf'],
+      '2023': ['gs', 'gst', 'dsp', 'ep', 'fsp', 'xp', 'xa', 'sm', 'smf'],
+      '2024': ['gs', 'gst', 'dsp', 'ep', 'fsp', 'xp', 'xa', 'sm', 'smf'],
+      '2025': ['gs', 'gst', 'dsp', 'ep', 'fsp', 'xp', 'xa', 'sm', 'smf'],
     },
     'Golf R': {
       '2012': ['ds', 'dsp', 'sm', 'ep', 'xp', 'xa', 'sm'],


### PR DESCRIPTION
Addresses #359

## Changes
- **SS:** BMW M5 (G90) 2025 — new entry
- **SS:** Porsche 718 Spyder RS 2024-2025 — new `Boxster Spyder RS (718)` entry
- **GST:** Subaru Impreza 2017-2025 — new entry (`hs` + `gst`)
- **FSP:** VW Golf GTI Mk8 2022-2025 (Limited Prep) — added `fsp` to 2022-2024, added 2025 row
- **ESP:** Jaguar F-Type R 2014-2024 (Limited Prep) — added `esp`; backfilled missing 2014-2017 years (entry previously started at 2018)

## No change needed
- **ESP Mini Cooper S** `JCE`→`JCW` typo: data already reads `JCW` (`Cooper S (including JCW & JCWGP except Countryman)`).

## Deferred (separate PR)
The large "Clean up Porsche classing" SS/AS/BS/CS section is a rulebook editorial regroup/rename (group by chassis). Our model-keyed data returns the same classes regardless of label, so it's cosmetic ~40-entry renaming — intentionally split out to keep this PR reviewable.

## Notes / judgment calls
- M5 (G90) classes `ss, sm, xp, xu` (mirrors `M5 CS` minus the CS-specific `sst`).
- 718 Spyder RS classes `ss, xp, xu, ssm` (mirrors `Cayman Spyder/Spyder RS`).
- Impreza 2017-2025 given `hs` (base Impreza NOC street class) + new `gst`.
- F-Type R: Fastrack line is "F-Type R (2014-2024)"; entry is `F-Type R & SVR`. Added `esp` across 2014-2024 and backfilled 2014-2017 as `as` (consistent with 2018+).

`src/common.js` regenerated via `go run main.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)