### PR TITLE
Issue 396: 2026 Honda Prelude Hybrid to GS

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -3841,6 +3841,9 @@ const allSoloCars = {
       '2000': ['hs', 'est', 'esp', 'smf', 'ep', 'xa'],
       '2001': ['hs', 'est', 'esp', 'smf', 'ep', 'xa'],
     },
+    'Prelude Hybrid': {
+      '2026': ['gs'],
+    },
     'S2000 (non-CR)': {
       '1999': ['cs', 'cst', 'dsp', 'ssm', 'fp', 'xa'],
       '2000': ['cs', 'cst', 'dsp', 'ssm', 'fp', 'xa'],

--- a/templates/common.js.tmpl
+++ b/templates/common.js.tmpl
@@ -3709,6 +3709,9 @@ const allSoloCars = {
       '2000': ['hs', 'est', 'esp', 'smf', 'ep', 'xa'],
       '2001': ['hs', 'est', 'esp', 'smf', 'ep', 'xa'],
     },
+    'Prelude Hybrid': {
+      '2026': ['gs'],
+    },
     'S2000 (non-CR)': {
       '1999': ['cs', 'cst', 'dsp', 'ssm', 'fp', 'xa'],
       '2000': ['cs', 'cst', 'dsp', 'ssm', 'fp', 'xa'],


### PR DESCRIPTION
Update `src/common.js` and `templates/common.js.tmpl` with 'Prelude Hybrid' for 2026 as GS.